### PR TITLE
New way to use RotP dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,2 @@
 Diver Down (Ripples of the Past addon)
 An addon mod for [Ripples of the Past](https://github.com/StandoByte/Ripples-of-the-Past), a mod for Minecraft based on JoJo's Bizarre Adventure.
-
-## Mod developer's (StandoByte) note
-Right now the dependency on the main mod is achieved by literally putting the mod's file into the libs/ directory of the project, which isn't the best. I know that mod developers are supposed to publish their mod's source into a Maven repository (or something along these lines), but I didn't figure out how to do that yet. So I would appreciate any tips from an experienced developers - if you would like to help, contact me on [the mod's Discord](https://discord.gg/4GcjnMnXP4) or open an issue in the repository.
-

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-// а тут я не могу поменять название и версию мода, его банально крашит
-
 buildscript {
     repositories {
         maven { url = 'https://maven.minecraftforge.net' }
@@ -14,9 +12,9 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.2'
+version = "${addon_version}"
 group = 'com.yourname.modid' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = 'RotP-WeatherReport'
+archivesBaseName = 'RotP-DiverDown'
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(8) // Mojang ships Java 8 to end users, so your mod should target Java 8.
 
@@ -116,8 +114,9 @@ minecraft {
 sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 repositories {
-    flatDir {
-        dirs 'libs'
+    maven {
+        name "RotP Maven"
+        url 'https://raw.githubusercontent.com/StandoByte/RotP-maven/main'
     }
 }
 
@@ -145,7 +144,7 @@ dependencies {
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
 
-	implementation fg.deobf("standobyte.jojo:${main_mod_file_name}")
+	compileOnly fg.deobf("standobyte.jojo:JJBA-RipplesOfThePast:${main_mod_version}")
 }
 
 // Example for how to get properties into the manifest for reading by the runtime..

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,7 @@
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
-main_mod_file_name=JJBA-RipplesOfThePast:1.16.5-0.2.2-pre3
+
+addon_version=1.0
+# https://github.com/StandoByte/RotP-maven/commits/main
+main_mod_version=1.16.5-0.2.2-pre3-snapshot-231119-a

--- a/src/main/java/com/hk47bot/rotp_dd/action/stand/DiverDownEntityPhasing.java
+++ b/src/main/java/com/hk47bot/rotp_dd/action/stand/DiverDownEntityPhasing.java
@@ -14,10 +14,10 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.potion.EffectInstance;
 import net.minecraft.world.World;
 
-public class DiverDownGetIntoMob extends StandEntityAction {
+public class DiverDownEntityPhasing extends StandEntityAction {
     public LivingEntity user;
     public LivingEntity targetent;
-    public DiverDownGetIntoMob(StandEntityAction.Builder builder) {
+    public DiverDownEntityPhasing(StandEntityAction.Builder builder) {
         super(builder);
     }
        @Override

--- a/src/main/java/com/hk47bot/rotp_dd/action/stand/DiverDownRetract.java
+++ b/src/main/java/com/hk47bot/rotp_dd/action/stand/DiverDownRetract.java
@@ -10,8 +10,8 @@ import com.hk47bot.rotp_dd.entity.stand.stands.DiverDownEntity;
 
 import net.minecraft.world.World;
 
-public class DiverDownReturnFromMob extends StandEntityAction {
-    public DiverDownReturnFromMob(StandEntityAction.Builder builder) {
+public class DiverDownRetract extends StandEntityAction {
+    public DiverDownRetract(StandEntityAction.Builder builder) {
         super(builder);
     }
     @Override


### PR DESCRIPTION
Поменял, как работает зависимость от Риплса - теперь не надо кидать сам файл мода в libs, вместо этого версия мода (снапшота) прописывается в gradle.properties. Теперь можно смотреть исходный код мода в самой IDE, не отходя от кассы, так сказатб. Только надо будет еще нажать кнопку Reload Gradle project, чтобы обновить зависимость.